### PR TITLE
added pod spec for CocoaPods support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ yarn add react-native-sha256
 react-native link
 ```
 
+## Adding with CocoaPods
+
+Add the RNSha256 pod to your list of application pods in your Podfile, using the path from the Podfile to the installed module:
+
+```
+pod 'RNSha256', :path => '../node_modules/react-native-sha256'
+```
+
+Install pods as usual:
+```
+pod install
+```
+
 # Usage
 
 Import the lib into your project:

--- a/RNSha256.podspec
+++ b/RNSha256.podspec
@@ -1,0 +1,21 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+Pod::Spec.new do |s|
+  s.name         = 'RNSha256'
+  s.version      = package["version"]
+  s.summary      = package["description"]
+  s.author       = package["author"]
+
+  s.homepage     = package["homepage"]
+
+  s.license      = package["license"]
+  s.platform     = :ios, "8.0"
+
+  s.source       = { :git => "https://github.com/itinance/react-native-sha256.git", :tag => "#{s.version}" }
+  s.source_files = "ios/**/*.{h,m,swift}"
+  s.preserve_paths  = "**/*.js"
+
+  s.dependency 'React'
+end

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "flow": "flow; test $? -eq 0 -o $? -eq 2"
   },
+  "homepage": "https://github.com/itinance/react-native-sha256",
   "repository": {
     "type": "git",
     "url": "git@github.com:itinance/react-native-sha256.git"


### PR DESCRIPTION
Hi there!

Thanks for creating this, just adding a small change to support CocoaPods. A lot of react native projects use this and makes setup for hybrid app much easier.

Let me know if you have any questions. 

Note: according to the react native docs: https://facebook.github.io/react-native/docs/linking-libraries-ios If an iOS project is using CocoaPods and your library has a podspec, then `react-native link` will use the pod for linking 