### PR TITLE
Update build.gradle to Android API 28 SDK version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         ndk {
@@ -19,6 +19,6 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.20.+'
+    implementation 'com.facebook.react:react-native:+'
 }
 


### PR DESCRIPTION
I have updated the Android SDK version and tools to the latest v28. Current versions in React Native 0.57 are set to 27 but the upcoming 0.58 has versions set to 28. Also changed the gradle dependency line to "implementation". "compile" is now obsolete and is slated to be removed from gradle by end of 2018.

The old version numbers were causing some build issues with some other 3rd party dependencies and the Android app compat support library in my project. The updated numbers resolve those.