### PR TITLE
Remove ImageLoader import

### DIFF
--- a/ios/sha256.m
+++ b/ios/sha256.m
@@ -9,8 +9,6 @@
 #import "sha256.h"
 
 #import <React/RCTUtils.h>
-#import <React/RCTImageLoader.h>
-
 #include <CommonCrypto/CommonDigest.h>
 
 @implementation sha256Lib


### PR DESCRIPTION
This PR removes the `RCTImageLoader` since it is not used. This also fixes the support for the React Native > 0.60 because the `RCTImageLoader` class was deprecated.