### PR TITLE
Update podspec to allow auto-linking for RN 60 and up

### DIFF
--- a/RNSha256.podspec
+++ b/RNSha256.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,swift}"
   s.preserve_paths  = "**/*.js"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
https://github.com/facebook/react-native/issues/25553#issuecomment-509534090

Referencing from this comment, the fix is to update the:
`s.dependency 'React'` to `s.dependency 'React-Core` to make everything auto-link properly in iOS. 

All react-native libraries with native iOS code should be doing this to keep up to date with the requirements in react-native 60 and up.