### PR TITLE
fix detox minSdkVersion error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "28.0.3"
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : 16
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
This change is needed because the minSdkVersion 16, creates an error when I build a debug project using detox, because detox needs minSdkVersion 21 or higher