### PR TITLE
Add methods to get the hash of a byte array

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,22 @@ pod install
 Import the lib into your project:
 
 ```javascript
-import { sha256 } from 'react-native-sha256';
+import { sha256, sha256Bytes } from 'react-native-sha256';
 ```
 
 Build a sha256-hash:
 
 ```javascript
 sha256("Test").then( hash => {
+    console.log(hash);
+})
+```
+
+```javascript
+const message = new Uint8Array(8);
+const bytes = Array.from(message);
+
+sha256Bytes(message).then( hash => {
     console.log(hash);
 })
 ```

--- a/android/src/main/java/com/sha256lib/Sha256Module.java
+++ b/android/src/main/java/com/sha256lib/Sha256Module.java
@@ -4,6 +4,7 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
 
@@ -28,6 +29,15 @@ public class Sha256Module extends ReactContextBaseJavaModule {
     return "sha256Lib";
   }
 
+  private static byte[] readableArrayToByteArray(ReadableArray readableArray) {
+      byte[] arr = new byte[readableArray.size()];
+      for (int i = 0; i < readableArray.size(); ++i) {
+          arr[i] = (byte) readableArray.getInt(i);
+      }
+
+      return arr;
+  }
+
   String buildHash(final String toHash, final String algo, final Integer length) throws NoSuchAlgorithmException, UnsupportedEncodingException {
     MessageDigest md = MessageDigest.getInstance(algo);
     md.update(toHash.getBytes("UTF-8"));
@@ -35,6 +45,13 @@ public class Sha256Module extends ReactContextBaseJavaModule {
     return String.format("%0" + length.toString() + "x", new java.math.BigInteger(1, digest));
   }
 
+  String buildHashWithBytes(final ReadableArray toHash, final String algo, final Integer length) throws NoSuchAlgorithmException, UnsupportedEncodingException {
+    MessageDigest md = MessageDigest.getInstance(algo);
+    byte[] arr = Sha256Module.readableArrayToByteArray(toHash);
+    md.update(arr);
+    byte[] digest = md.digest();
+    return String.format("%0" + length.toString() + "x", new java.math.BigInteger(1, digest));
+  }
 
   @ReactMethod
   public void sha256(final String toHash, Promise promise) {
@@ -51,9 +68,37 @@ public class Sha256Module extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void sha256Bytes(final ReadableArray toHash, Promise promise) {
+      try {
+          String hash = buildHashWithBytes(toHash, "SHA-256", 64);
+          promise.resolve(hash);
+      } catch (NoSuchAlgorithmException e) {
+          e.printStackTrace();
+          promise.reject("sha256", e.getMessage());
+      } catch (UnsupportedEncodingException e) {
+          e.printStackTrace();
+          promise.reject("sha256", e.getMessage());
+      }
+  }
+
+  @ReactMethod
   public void sha1(final String toHash, Promise promise) {
       try {
           String hash = buildHash(toHash, "SHA-1", 40);
+          promise.resolve(hash);
+      } catch (NoSuchAlgorithmException e) {
+          e.printStackTrace();
+          promise.reject("sha1", e.getMessage());
+      } catch (UnsupportedEncodingException e) {
+          e.printStackTrace();
+          promise.reject("sha1", e.getMessage());
+      }
+  }
+
+  @ReactMethod
+  public void sha1Bytes(final ReadableArray toHash, Promise promise) {
+      try {
+          String hash = buildHashWithBytes(toHash, "SHA-1", 40);
           promise.resolve(hash);
       } catch (NoSuchAlgorithmException e) {
           e.printStackTrace();

--- a/ios/sha256.m
+++ b/ios/sha256.m
@@ -32,6 +32,31 @@ typedef unsigned char (*DIGEST_FUNCTION)(const void *data, CC_LONG len, unsigned
     return ret;
 }
 
+- (NSString*) calcHashWithBytes: (NSArray *) subject withDigestFunction: (DIGEST_FUNCTION) digest withDigestLength: (int) digestLength {
+    NSUInteger count = [subject count];
+    unsigned char *array = (unsigned char *) malloc(count);
+
+    if (array == nil) return nil;
+
+    for (int i = 0; i < count; ++i) {
+        array[i] = [[subject objectAtIndex: i] unsignedCharValue];
+    }
+
+    unsigned char result[digestLength];
+
+    digest(array, count, result);
+
+    free(array);
+
+    NSMutableString *ret = [NSMutableString stringWithCapacity:digestLength * 2];
+    for(int i = 0; i < digestLength; i++)
+    {
+        [ret appendFormat:@"%02x",result[i]];
+    }
+
+    return ret;
+}
+
 RCT_EXPORT_METHOD(sha1: (NSString *) data
                   resolver: (RCTPromiseResolveBlock) resolve
                   rejecter: (RCTPromiseRejectBlock) reject)
@@ -41,6 +66,20 @@ RCT_EXPORT_METHOD(sha1: (NSString *) data
     resolve(ret);
 }
 
+RCT_EXPORT_METHOD(sha1Bytes: (NSArray *) data
+                  resolver: (RCTPromiseResolveBlock) resolve
+                  rejecter: (RCTPromiseRejectBlock) reject)
+
+{
+    NSString *ret = [self calcHashWithBytes:data withDigestFunction:CC_SHA1 withDigestLength: CC_SHA1_DIGEST_LENGTH];
+
+    if (ret) {
+        resolve(ret);
+    } else {
+        reject(@"error", @"out of memory", nil);
+    }
+}
+
 RCT_EXPORT_METHOD(sha256: (NSString *) data
                   resolver: (RCTPromiseResolveBlock) resolve
                   rejecter: (RCTPromiseRejectBlock) reject)
@@ -48,6 +87,20 @@ RCT_EXPORT_METHOD(sha256: (NSString *) data
 {
     NSString *ret = [self calcHash:data withDigestFunction:CC_SHA256 withDigestLength: CC_SHA256_DIGEST_LENGTH];
     resolve(ret);
+}
+
+RCT_EXPORT_METHOD(sha256Bytes: (NSArray *) data
+                  resolver: (RCTPromiseResolveBlock) resolve
+                  rejecter: (RCTPromiseRejectBlock) reject)
+
+{
+    NSString *ret = [self calcHashWithBytes:data withDigestFunction:CC_SHA256 withDigestLength: CC_SHA256_DIGEST_LENGTH];
+
+    if (ret) {
+        resolve(ret);
+    } else {
+        reject(@"error", @"out of memory", nil);
+    }
 }
 
 @end

--- a/sha256.d.ts
+++ b/sha256.d.ts
@@ -1,4 +1,6 @@
 declare module 'react-native-sha256' {
     export const sha1: (input: string) => Promise<string>;
+    export const sha1Bytes: (input: Array) => Promise<string>;
     export const sha256: (input: string) => Promise<string>;
+    export const sha256Bytes: (input: Array) => Promise<string>;
 }

--- a/sha256.js
+++ b/sha256.js
@@ -12,6 +12,14 @@ export function sha256(data: string) {
   return sha256Lib.sha256(data);
 }
 
+export function sha256Bytes(data: Array) {
+  return sha256Lib.sha256Bytes(data);
+}
+ 
 export function sha1(data: string) {
   return sha256Lib.sha1(data);
+}
+
+export function sha1Bytes(data: Array) {
+  return sha256Lib.sha1Bytes(data);
 }


### PR DESCRIPTION
The existing string methods use strlen() under the hood and thus cannot handle binary strings with zero (0x00) bytes in the data.

This pull request adds the ability to take the hash of a `Uint8Array`.